### PR TITLE
Add TSG for KVAAlreadyDeployedCustomerError

### DIFF
--- a/KVAAlreadyDeployedCustomerError.md
+++ b/KVAAlreadyDeployedCustomerError.md
@@ -1,0 +1,24 @@
+**Error Code ID:** KVAAlreadyDeployedCustomerError
+
+**Error message**
+
+An appliance already exists with this configuration (deployment phase: MachineRunning) - please call Delete before reattempting deployment.
+
+**Explanation**
+
+During the Azure Arc resource bridge deployment, an Appliance virtual machine is created on the selected Hostgroup/Cloud in the VMM Server. If a virtual machine with the same name already exists on the given VMM Server, you may encounter the above error.
+
+To resolve this, check if a virtual machine with the same name exists on any host associated with the VMM Server and manually delete it before proceeding.
+
+If you re-run the onboarding script from the same folder where the three configuration YAML files (*-resource.yaml, *-infra.yaml, and *-appliance.yaml) from the previous attempt are stored, the script automatically appends the -force flag to the Appliance creation command. This flag ensures that any existing virtual machine with the same name is deleted before creating a new one.
+
+However, there are scenarios where the -force flag may not resolve the issue, and the error may still appear during script execution. This could be due to the virtual machine being in a failed state, such as HostNotResponding or CreationFailed, where deletion is not supported.
+
+- Check the host where the virtual machine was created and resolve any issues with the host.
+- Manually delete the virtual machine from the VMM Server.
+- Delete the Arc resource bridge resource from Azure.
+- Re-run the Onboarding script.
+
+<br>
+
+> **Recommendation:**  It is best practice to run the onboarding script from a separate folder, as the generated configuration YAML files are useful for Day-N operations. However, if re-running from the same folder, ensure the -force flag is used to clean up any previous resources before retrying.

--- a/KVAAlreadyDeployedCustomerError.md
+++ b/KVAAlreadyDeployedCustomerError.md
@@ -21,4 +21,4 @@ However, there are scenarios where the -force flag may not resolve the issue, an
 
 <br>
 
-> **Recommendation:**  It is best practice to run the onboarding script from a separate folder, as the generated configuration YAML files are useful for Day-N operations. However, if re-running from the same folder, ensure the -force flag is used to clean up any previous resources before retrying.
+> **Note:**  For a fresh deployment, it is best practice to run the onboarding script from a separate folder, as the generated configuration YAML files are useful for Day-N operations. However, if re-running the onboarding script from the same folder after a failed execution, ensure that the `-force` flag is used to clean up any previous resources before retrying.

--- a/ValidateInsufficientLibSharePermission.md
+++ b/ValidateInsufficientLibSharePermission.md
@@ -9,6 +9,10 @@ VMM Server doesn't have write permission into the specified library share : \\\\
 
 During Azure Arc resource bridge (ARB) deployment on a SCVMM managed datacenter, a few validations are performed before the ARB VM deployment. One such validation is to validate if the the library server specified has write permissions. VMM Server can only create the ARB VM if the required VHDX/VHD file is present in the library share. For ARB VM deployment, a special customized Mariner VHDX is required and the same is downloaded during the onboarding script execution and copied to the VMM library share. Hence, the onboarding script prompts to select a library share during the onboarding script execution and on selection, validation check for the write permission on the chosen library share happens. In addition to write permission, a minimum of 10GB of free space is required in the selected library share.
 
+> **Note:** A Library Share containing whitespace in its path (e.g., \\LibraryServer\Library Share) is not supported. 
+Importing resources from such a Library Share is not a supported scenario in the VMM console or when using the Import-SCLibraryPhysicalResource command. Check VMM jobs for the failure. <br>
+To resolve the issue, use a Library Share without any whitespace in its path and re-run the ARB onboarding script.
+
 If the above error message is encountered, you can validate if the libary share has the write permissions by following the below steps:
 - RDP to the VMM server machine.
 - Open a PowerShell admin prompt and browse to SystemDrive\ProgramData folder (for e.g C:\ProgramData)
@@ -28,4 +32,4 @@ If the above error message is encountered, you can validate if the libary share 
 
 - Once this works, re-run the appliance onboarding script from the workstation machine and select the library share which was fixed by the above debugging.
 
-- You can also file a support ticket to fix the library issue by working with Microsoft engineers. 
+- You can also file a support ticket to fix the library issue by working with Microsoft engineers.


### PR DESCRIPTION
This PR contains following changes:
1. Added TSG for KVAAlreadyDeployedCustomerError
2. Updated TSG for ValidateInsufficientLibSharePermission to include note to not use Library Share with Whitespaces in the path.